### PR TITLE
fix(cli): remove placeholder implementations and dead code

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -78,10 +78,7 @@ program
   .command("check")
   .description("check for issues in translations and configuration")
   .option("--missing", "check for missing translations")
-  .option("--unused", "check for unused translation keys")
-  .option("--duplicates", "check for duplicate keys")
   .option("--format-errors", "check for format errors in translations")
-  .option("--fix", "automatically fix issues where possible")
   .action(checkCommand);
 
 // Check-config command
@@ -129,15 +126,6 @@ program
 
 // Next.js command
 program.addCommand(nextjsCommand);
-
-// Add subcommands
-program
-  .command("completion")
-  .description("generate shell completion scripts")
-  .option("--shell <shell>", "shell type (bash|zsh|fish)", "bash")
-  .action((_options) => {
-    console.log("Shell completion not implemented yet");
-  });
 
 // Error handling
 program.exitOverride((err) => {

--- a/packages/cli/src/commands/check.ts
+++ b/packages/cli/src/commands/check.ts
@@ -6,10 +6,7 @@ import { validateTranslations } from "@intl-party/core";
 
 export interface CheckOptions {
   missing?: boolean;
-  unused?: boolean;
-  duplicates?: boolean;
   formatErrors?: boolean;
-  fix?: boolean;
   config?: string;
   verbose?: boolean;
 }
@@ -100,21 +97,6 @@ export async function checkCommand(options: CheckOptions) {
       spinner.succeed("Format errors check completed");
     }
 
-    // Check for unused keys (placeholder)
-    if (options.unused) {
-      spinner.start("Checking for unused keys...");
-      // This would require analyzing source code
-      // For now, just a placeholder
-      spinner.succeed("Unused keys check completed");
-    }
-
-    // Check for duplicates (placeholder)
-    if (options.duplicates) {
-      spinner.start("Checking for duplicate keys...");
-      // This would check for duplicate values or similar keys
-      spinner.succeed("Duplicate keys check completed");
-    }
-
     // Report results
     if (issues.length === 0) {
       console.log(chalk.green("✓ No issues found!"));
@@ -155,21 +137,6 @@ export async function checkCommand(options: CheckOptions) {
       });
 
       console.log();
-    }
-
-    // Auto-fix if requested
-    if (options.fix) {
-      spinner.start("Attempting to fix issues...");
-
-      let fixedCount = 0;
-      // Implement auto-fixing logic here
-      // For now, just a placeholder
-
-      if (fixedCount > 0) {
-        spinner.succeed(`Fixed ${fixedCount} issue(s)`);
-      } else {
-        spinner.info("No issues could be automatically fixed");
-      }
     }
 
     // Exit with error code if there are errors

--- a/packages/cli/src/commands/generate.ts
+++ b/packages/cli/src/commands/generate.ts
@@ -567,13 +567,6 @@ async function autoDetectMessages(options?: GenerateOptions): Promise<{
 
   // Auto-detect locales from directory structure
   const localeDirs = await fs.readdir(messagesDir);
-  const detectedLocales = localeDirs.filter(async (dir) => {
-    const localePath = path.join(messagesDir!, dir);
-    const stat = await fs.stat(localePath);
-    return stat.isDirectory();
-  });
-
-  // Wait for all stat checks to complete
   const validLocales = [];
   for (const dir of localeDirs) {
     const localePath = path.join(messagesDir!, dir);


### PR DESCRIPTION
## Summary
- Remove no-op placeholder options (`--unused`, `--duplicates`, `--fix`) from the `check` command that did nothing
- Remove stub `completion` command that only printed "not implemented yet"
- Remove dead `detectedLocales` variable in `generate.ts` (immediately replaced by proper `validLocales` loop)

## Test plan
- [ ] `pnpm build` succeeds
- [ ] CLI `check` command still works with `--missing` and `--format-errors` options

🤖 Generated with [Claude Code](https://claude.com/claude-code)