### PR TITLE
refactor(core): remove unused public exports

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -30,9 +30,6 @@ export type {
   MessageFormatConfig,
 } from "./types";
 
-// Import for internal use
-import type { I18nConfig } from "./types";
-
 // Utilities
 export {
   TranslationStore,
@@ -48,10 +45,6 @@ export {
   isLegacyFormat,
   detectMessageFormat,
   formatICUMessage,
-  isICULibraryAvailable,
-  clearICUCache,
-  getICUCacheStats,
-  DEFAULT_MESSAGE_FORMAT_CONFIG,
 } from "./utils/icu-formatter";
 
 // Detection
@@ -72,86 +65,3 @@ export {
 // Version
 export const VERSION = "0.1.0";
 
-// Default configurations
-export const DEFAULT_CONFIG: Partial<I18nConfig> = {
-  locales: ["en"],
-  defaultLocale: "en",
-  namespaces: ["common"],
-  detection: {
-    strategies: ["acceptLanguage"],
-    storageKey: "locale",
-  },
-  validation: {
-    strict: false,
-    logMissing: true,
-    throwOnMissing: false,
-    validateFormats: true,
-  },
-  cache: {
-    maxSize: 1000,
-    ttl: 0, // No TTL by default
-    strategy: "lru",
-  },
-};
-
-// Helper functions
-export function isValidLocale(locale: string): boolean {
-  try {
-    new Intl.Locale(locale);
-    return true;
-  } catch {
-    return false;
-  }
-}
-
-export function normalizeLocale(locale: string): string {
-  try {
-    return new Intl.Locale(locale).toString();
-  } catch {
-    return locale.toLowerCase().replace("_", "-");
-  }
-}
-
-export function getLocaleDirection(locale: string): "ltr" | "rtl" {
-  const rtlLocales = [
-    "ar",
-    "arc",
-    "ckb",
-    "dv",
-    "fa",
-    "ha",
-    "he",
-    "khw",
-    "ks",
-    "ku",
-    "ps",
-    "sd",
-    "ur",
-    "yi",
-  ];
-
-  const baseLocale = locale.split("-")[0];
-  return rtlLocales.includes(baseLocale) ? "rtl" : "ltr";
-}
-
-export function parseLocale(locale: string): {
-  language: string;
-  region?: string;
-  script?: string;
-} {
-  try {
-    const intlLocale = new Intl.Locale(locale);
-    return {
-      language: intlLocale.language,
-      region: intlLocale.region,
-      script: intlLocale.script,
-    };
-  } catch {
-    const parts = locale.split("-");
-    return {
-      language: parts[0],
-      region: parts[1],
-      script: parts[2],
-    };
-  }
-}


### PR DESCRIPTION
## Summary
- Remove `DEFAULT_CONFIG` constant (never imported by any consumer)
- Remove utility functions not used by any other package: `isValidLocale`, `normalizeLocale`, `getLocaleDirection`, `parseLocale`
- Remove internal ICU helpers from public API surface: `isICULibraryAvailable`, `clearICUCache`, `getICUCacheStats`, `DEFAULT_MESSAGE_FORMAT_CONFIG` (functions remain available internally)

## Test plan
- [ ] `pnpm build` succeeds
- [ ] `pnpm test` passes (internal usage unaffected)
- [ ] Other packages still compile (they never imported these)

🤖 Generated with [Claude Code](https://claude.com/claude-code)