### PR TITLE
feat(core): support dot-escaped translation keys

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -40,6 +40,7 @@ export {
   deepMerge,
   flattenTranslations,
   unflattenTranslations,
+  splitEscapedDots,
 } from "./utils/translation";
 
 // ICU MessageFormat utilities

--- a/packages/core/src/utils/translation.test.ts
+++ b/packages/core/src/utils/translation.test.ts
@@ -1,0 +1,209 @@
+import { describe, it, expect } from "vitest";
+import {
+  TranslationStore,
+  flattenTranslations,
+  unflattenTranslations,
+  splitEscapedDots,
+} from "./translation";
+
+describe("splitEscapedDots", () => {
+  it("should split on unescaped dots", () => {
+    expect(splitEscapedDots("a.b.c")).toEqual(["a", "b", "c"]);
+  });
+
+  it("should not split on escaped dots", () => {
+    expect(splitEscapedDots("a\\.b")).toEqual(["a.b"]);
+  });
+
+  it("should handle mixed escaped and unescaped dots", () => {
+    expect(splitEscapedDots("a\\.b.c")).toEqual(["a.b", "c"]);
+  });
+
+  it("should handle multiple escaped dots", () => {
+    expect(splitEscapedDots("a\\.b\\.c")).toEqual(["a.b.c"]);
+  });
+
+  it("should handle escaped dot at the end", () => {
+    expect(splitEscapedDots("a\\.")).toEqual(["a."]);
+  });
+
+  it("should handle no dots", () => {
+    expect(splitEscapedDots("hello")).toEqual(["hello"]);
+  });
+
+  it("should handle empty string", () => {
+    expect(splitEscapedDots("")).toEqual([""]);
+  });
+
+  it("should handle multiple segments with escaped dots in the middle", () => {
+    expect(splitEscapedDots("a.b\\.c.d")).toEqual(["a", "b.c", "d"]);
+  });
+});
+
+describe("TranslationStore - dot-escaped keys", () => {
+  it("should access flat keys with escaped dots", () => {
+    const store = new TranslationStore();
+    store.addTranslations("en", "common", {
+      "a.b": "flat value",
+    });
+
+    expect(store.getTranslation("a\\.b", "en", "common")).toBe("flat value");
+  });
+
+  it("should still traverse nested keys with unescaped dots", () => {
+    const store = new TranslationStore();
+    store.addTranslations("en", "common", {
+      a: {
+        b: "nested value",
+      },
+    });
+
+    expect(store.getTranslation("a.b", "en", "common")).toBe("nested value");
+  });
+
+  it("should distinguish between flat and nested keys", () => {
+    const store = new TranslationStore();
+    store.addTranslations("en", "common", {
+      "a.b": "flat value",
+      a: {
+        b: "nested value",
+      },
+    });
+
+    expect(store.getTranslation("a\\.b", "en", "common")).toBe("flat value");
+    expect(store.getTranslation("a.b", "en", "common")).toBe("nested value");
+  });
+
+  it("should handle multiple escaped dots in a key", () => {
+    const store = new TranslationStore();
+    store.addTranslations("en", "common", {
+      "x.y.z": "triple dot",
+    });
+
+    expect(store.getTranslation("x\\.y\\.z", "en", "common")).toBe(
+      "triple dot",
+    );
+  });
+
+  it("should handle mixed escaped and unescaped dots", () => {
+    const store = new TranslationStore();
+    store.addTranslations("en", "common", {
+      nav: {
+        "home.page": "Home Page",
+      },
+    });
+
+    expect(store.getTranslation("nav.home\\.page", "en", "common")).toBe(
+      "Home Page",
+    );
+  });
+
+  it("should return missing key format for non-existent escaped key", () => {
+    const store = new TranslationStore();
+    store.addTranslations("en", "common", {
+      a: { b: "nested" },
+    });
+
+    expect(store.getTranslation("a\\.b", "en", "common")).toBe(
+      "[common:a\\.b]",
+    );
+  });
+
+  it("should work with hasTranslation for escaped dot keys", () => {
+    const store = new TranslationStore();
+    store.addTranslations("en", "common", {
+      "a.b": "flat value",
+    });
+
+    expect(store.hasTranslation("a\\.b", "en", "common")).toBe(true);
+    expect(store.hasTranslation("a.b", "en", "common")).toBe(false);
+  });
+
+  it("should work with fallback chain and escaped dots", () => {
+    const store = new TranslationStore({ fallbackChain: { es: "en" } });
+    store.addTranslations("en", "common", {
+      "config.key": "Config Key",
+    });
+
+    expect(store.getTranslation("config\\.key", "es", "common")).toBe(
+      "Config Key",
+    );
+  });
+});
+
+describe("flattenTranslations - dot escaping", () => {
+  it("should escape dots in keys that contain literal dots", () => {
+    const nested = {
+      "a.b": "value",
+    };
+    const flat = flattenTranslations(nested);
+    expect(flat).toEqual({ "a\\.b": "value" });
+  });
+
+  it("should not escape keys without dots", () => {
+    const nested = {
+      simple: "value",
+    };
+    const flat = flattenTranslations(nested);
+    expect(flat).toEqual({ simple: "value" });
+  });
+
+  it("should handle nested objects with dotted keys", () => {
+    const nested = {
+      nav: {
+        "home.page": "Home Page",
+      },
+    };
+    const flat = flattenTranslations(nested);
+    expect(flat).toEqual({ "nav.home\\.page": "Home Page" });
+  });
+
+  it("should handle multiple levels of nesting with dotted keys", () => {
+    const nested = {
+      a: {
+        b: {
+          "c.d": "deep value",
+        },
+      },
+    };
+    const flat = flattenTranslations(nested);
+    expect(flat).toEqual({ "a.b.c\\.d": "deep value" });
+  });
+});
+
+describe("unflattenTranslations - dot escaping", () => {
+  it("should unflatten escaped dots into flat keys", () => {
+    const flat = { "a\\.b": "value" };
+    const nested = unflattenTranslations(flat);
+    expect(nested).toEqual({ "a.b": "value" });
+  });
+
+  it("should unflatten unescaped dots into nested objects", () => {
+    const flat = { "a.b": "value" };
+    const nested = unflattenTranslations(flat);
+    expect(nested).toEqual({ a: { b: "value" } });
+  });
+
+  it("should handle mixed escaped and unescaped dots", () => {
+    const flat = { "nav.home\\.page": "Home Page" };
+    const nested = unflattenTranslations(flat);
+    expect(nested).toEqual({ nav: { "home.page": "Home Page" } });
+  });
+
+  it("should roundtrip with flattenTranslations", () => {
+    const original = {
+      simple: "value1",
+      nested: {
+        key: "value2",
+      },
+      "dotted.key": "value3",
+      parent: {
+        "child.key": "value4",
+      },
+    };
+
+    const flat = flattenTranslations(original);
+    const restored = unflattenTranslations(flat);
+    expect(restored).toEqual(original);
+  });
+});

--- a/packages/core/src/utils/translation.ts
+++ b/packages/core/src/utils/translation.ts
@@ -70,6 +70,38 @@ function createStableCacheKey(options: TranslationOptions | undefined): string {
   }
 }
 
+/**
+ * Splits a dot-separated path while respecting escaped dots (`\\.`).
+ * - Unescaped dots are treated as nesting separators.
+ * - `\\.` sequences are treated as literal dots within a single key segment.
+ *
+ * Examples:
+ *   "a.b"     → ["a", "b"]
+ *   "a\\.b"   → ["a.b"]
+ *   "a\\.b.c" → ["a.b", "c"]
+ */
+export function splitEscapedDots(path: string): string[] {
+  const segments: string[] = [];
+  let current = "";
+
+  for (let i = 0; i < path.length; i++) {
+    if (path[i] === "\\" && i + 1 < path.length && path[i + 1] === ".") {
+      // Escaped dot — include literal dot
+      current += ".";
+      i++; // skip the dot
+    } else if (path[i] === ".") {
+      // Unescaped dot — segment separator
+      segments.push(current);
+      current = "";
+    } else {
+      current += path[i];
+    }
+  }
+
+  segments.push(current);
+  return segments;
+}
+
 export interface TranslationStoreOptions {
   fallbackChain?: Record<Locale, Locale>;
   maxCacheSize?: number;
@@ -204,7 +236,7 @@ export class TranslationStore {
   ): TranslationValue | undefined {
     if (!obj || typeof obj !== "object") return undefined;
 
-    const keys = path.split(".");
+    const keys = splitEscapedDots(path);
     let current: TranslationValue | NestedTranslations | Translations = obj;
 
     for (const key of keys) {
@@ -468,7 +500,9 @@ export function flattenTranslations(
   const result: Record<string, TranslationValue> = {};
 
   for (const [key, value] of Object.entries(translations)) {
-    const fullKey = prefix ? `${prefix}.${key}` : key;
+    // Escape literal dots in key segments so they are not confused with nesting separators
+    const escapedKey = key.replace(/\./g, "\\.");
+    const fullKey = prefix ? `${prefix}.${escapedKey}` : escapedKey;
 
     if (typeof value === "object" && value !== null && !Array.isArray(value)) {
       Object.assign(
@@ -489,7 +523,7 @@ export function unflattenTranslations(
   const result: NestedTranslations = {};
 
   for (const [key, value] of Object.entries(flat)) {
-    const keys = key.split(".");
+    const keys = splitEscapedDots(key);
     let current = result;
 
     for (let i = 0; i < keys.length - 1; i++) {


### PR DESCRIPTION
## Summary
- Support backslash-escaped dots in translation keys (`t("a\\.b")` accesses flat key `"a.b"`)
- Backward compatible — existing dot-separated nested keys still work unchanged
- Updated `getNestedValue()`, `flattenTranslations()`, and `unflattenTranslations()`
- Comprehensive test coverage for ambiguous cases

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)