### PR TITLE
feat: add VS Code extension for translation key autocomplete

### DIFF
--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -1,0 +1,60 @@
+{
+  "name": "intl-party-vscode",
+  "displayName": "intl-party",
+  "description": "VS Code extension for intl-party - translation key autocomplete, hover preview, diagnostics, and go-to-definition",
+  "version": "0.1.0",
+  "publisher": "intl-party",
+  "engines": {
+    "vscode": "^1.85.0"
+  },
+  "categories": [
+    "Programming Languages",
+    "Linters",
+    "Other"
+  ],
+  "activationEvents": [
+    "workspaceContains:**/*.json"
+  ],
+  "main": "./dist/extension.js",
+  "contributes": {
+    "configuration": {
+      "title": "intl-party",
+      "properties": {
+        "intl-party.translationFiles": {
+          "type": "string",
+          "default": "**/locales/**/*.json",
+          "description": "Glob pattern for translation JSON files"
+        },
+        "intl-party.defaultLocale": {
+          "type": "string",
+          "default": "en",
+          "description": "Default locale used for hover previews and diagnostics"
+        }
+      }
+    },
+    "commands": [
+      {
+        "command": "intl-party.refreshIndex",
+        "title": "intl-party: Refresh Translation Index"
+      }
+    ]
+  },
+  "scripts": {
+    "build": "tsup src/extension.ts --format cjs --external vscode --minify",
+    "dev": "tsup src/extension.ts --format cjs --external vscode --watch",
+    "typecheck": "tsc --noEmit",
+    "clean": "rm -rf dist",
+    "package": "vsce package"
+  },
+  "devDependencies": {
+    "@types/vscode": "^1.85.0",
+    "tsup": "^8.5.1",
+    "typescript": "^5.3.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/RodrigoEspinosa/intl-party.git",
+    "directory": "packages/vscode-extension"
+  },
+  "license": "MIT"
+}

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -1,0 +1,66 @@
+import * as vscode from "vscode";
+import { TranslationIndex } from "./translation-index";
+import { TranslationCompletionProvider } from "./providers/completion";
+import { TranslationHoverProvider } from "./providers/hover";
+import { TranslationDiagnosticsProvider } from "./providers/diagnostics";
+import { TranslationDefinitionProvider } from "./providers/definition";
+
+let index: TranslationIndex;
+
+export async function activate(
+  context: vscode.ExtensionContext,
+): Promise<void> {
+  index = new TranslationIndex();
+  await index.initialize();
+
+  const selector: vscode.DocumentSelector = [
+    { scheme: "file", language: "typescript" },
+    { scheme: "file", language: "typescriptreact" },
+    { scheme: "file", language: "javascript" },
+    { scheme: "file", language: "javascriptreact" },
+  ];
+
+  // Completion provider triggered inside t(" contexts
+  const completionProvider = new TranslationCompletionProvider(index);
+  context.subscriptions.push(
+    vscode.languages.registerCompletionItemProvider(
+      selector,
+      completionProvider,
+      '"',
+      "'",
+      ".",
+    ),
+  );
+
+  // Hover provider
+  const hoverProvider = new TranslationHoverProvider(index);
+  context.subscriptions.push(
+    vscode.languages.registerHoverProvider(selector, hoverProvider),
+  );
+
+  // Diagnostics
+  const diagnosticsProvider = new TranslationDiagnosticsProvider(index);
+  context.subscriptions.push(diagnosticsProvider);
+
+  // Go-to-definition
+  const definitionProvider = new TranslationDefinitionProvider(index);
+  context.subscriptions.push(
+    vscode.languages.registerDefinitionProvider(selector, definitionProvider),
+  );
+
+  // Refresh command
+  context.subscriptions.push(
+    vscode.commands.registerCommand("intl-party.refreshIndex", async () => {
+      await index.refresh();
+      vscode.window.showInformationMessage(
+        "intl-party: Translation index refreshed",
+      );
+    }),
+  );
+
+  context.subscriptions.push(index);
+}
+
+export function deactivate(): void {
+  index?.dispose();
+}

--- a/packages/vscode-extension/src/providers/completion.ts
+++ b/packages/vscode-extension/src/providers/completion.ts
@@ -1,0 +1,55 @@
+import * as vscode from "vscode";
+import { TranslationIndex } from "../translation-index";
+
+/**
+ * Provides autocomplete suggestions for translation keys when the cursor
+ * is inside a t("...") or t('...') call.
+ */
+export class TranslationCompletionProvider
+  implements vscode.CompletionItemProvider
+{
+  constructor(private readonly index: TranslationIndex) {}
+
+  provideCompletionItems(
+    document: vscode.TextDocument,
+    position: vscode.Position,
+  ): vscode.CompletionItem[] | undefined {
+    const lineText = document.lineAt(position).text;
+    const linePrefix = lineText.substring(0, position.character);
+
+    // Match t(", t(', useTranslation and then t(" patterns
+    const tCallMatch = linePrefix.match(/\bt\(\s*["']([^"']*)$/);
+    if (!tCallMatch) {
+      return undefined;
+    }
+
+    const typedPrefix = tCallMatch[1];
+    const defaultLocale = vscode.workspace
+      .getConfiguration("intl-party")
+      .get<string>("defaultLocale", "en");
+
+    const keys = this.index.getAllKeys();
+
+    return keys
+      .filter((key) => key.startsWith(typedPrefix))
+      .map((key) => {
+        const item = new vscode.CompletionItem(
+          key,
+          vscode.CompletionItemKind.Text,
+        );
+
+        const value = this.index.getValue(key, defaultLocale);
+        if (value) {
+          item.detail = value;
+          item.documentation = new vscode.MarkdownString(
+            `**${defaultLocale}**: ${value}`,
+          );
+        }
+
+        // Sort matched keys by length so shorter (more specific) keys rank higher
+        item.sortText = String(key.length).padStart(5, "0") + key;
+
+        return item;
+      });
+  }
+}

--- a/packages/vscode-extension/src/providers/definition.ts
+++ b/packages/vscode-extension/src/providers/definition.ts
@@ -1,0 +1,90 @@
+import * as vscode from "vscode";
+import { TranslationIndex } from "../translation-index";
+
+/**
+ * Provides go-to-definition for translation keys, jumping to the JSON file
+ * where the key is defined.
+ */
+export class TranslationDefinitionProvider
+  implements vscode.DefinitionProvider
+{
+  constructor(private readonly index: TranslationIndex) {}
+
+  provideDefinition(
+    document: vscode.TextDocument,
+    position: vscode.Position,
+  ): vscode.LocationLink[] | undefined {
+    const key = this.extractKeyAtPosition(document, position);
+    if (!key) {
+      return undefined;
+    }
+
+    const defaultLocale = vscode.workspace
+      .getConfiguration("intl-party")
+      .get<string>("defaultLocale", "en");
+
+    const entries = this.index.getEntries(key);
+    if (entries.length === 0) {
+      return undefined;
+    }
+
+    // Prefer the default locale entry, fall back to first available
+    const sorted = entries.sort((a, b) => {
+      if (a.locale === defaultLocale) return -1;
+      if (b.locale === defaultLocale) return 1;
+      return a.locale.localeCompare(b.locale);
+    });
+
+    // Build the origin selection range (the key string in the source file)
+    const line = document.lineAt(position).text;
+    const pattern = /\bt\(\s*["']([^"']+)["']/g;
+    let originRange: vscode.Range | undefined;
+    let found: RegExpExecArray | null;
+
+    while ((found = pattern.exec(line)) !== null) {
+      const keyStart = found.index + found[0].indexOf(found[1]);
+      const keyEnd = keyStart + found[1].length;
+      if (position.character >= keyStart && position.character <= keyEnd) {
+        originRange = new vscode.Range(
+          new vscode.Position(position.line, keyStart),
+          new vscode.Position(position.line, keyEnd),
+        );
+        break;
+      }
+    }
+
+    return sorted.map((entry) => {
+      const targetUri = vscode.Uri.file(entry.filePath);
+      // Point to the beginning of the file; a more advanced implementation
+      // could parse the JSON to find the exact line.
+      const targetRange = new vscode.Range(0, 0, 0, 0);
+
+      return {
+        originSelectionRange: originRange,
+        targetUri,
+        targetRange,
+        targetSelectionRange: targetRange,
+      } satisfies vscode.LocationLink;
+    });
+  }
+
+  private extractKeyAtPosition(
+    document: vscode.TextDocument,
+    position: vscode.Position,
+  ): string | undefined {
+    const line = document.lineAt(position).text;
+    const pattern = /\bt\(\s*["']([^"']+)["']/g;
+    let found: RegExpExecArray | null;
+
+    while ((found = pattern.exec(line)) !== null) {
+      const keyStart = found.index + found[0].indexOf(found[1]);
+      const keyEnd = keyStart + found[1].length;
+
+      if (position.character >= keyStart && position.character <= keyEnd) {
+        return found[1];
+      }
+    }
+
+    return undefined;
+  }
+}

--- a/packages/vscode-extension/src/providers/diagnostics.ts
+++ b/packages/vscode-extension/src/providers/diagnostics.ts
@@ -1,0 +1,112 @@
+import * as vscode from "vscode";
+import { TranslationIndex } from "../translation-index";
+
+/**
+ * Provides diagnostics (warning squiggles) for translation keys that are
+ * missing from one or more locales.
+ */
+export class TranslationDiagnosticsProvider implements vscode.Disposable {
+  private readonly diagnosticCollection: vscode.DiagnosticCollection;
+  private readonly disposables: vscode.Disposable[] = [];
+
+  constructor(private readonly index: TranslationIndex) {
+    this.diagnosticCollection =
+      vscode.languages.createDiagnosticCollection("intl-party");
+
+    // Refresh diagnostics when documents change
+    this.disposables.push(
+      vscode.workspace.onDidChangeTextDocument((e) => {
+        this.updateDiagnostics(e.document);
+      }),
+    );
+
+    this.disposables.push(
+      vscode.workspace.onDidOpenTextDocument((doc) => {
+        this.updateDiagnostics(doc);
+      }),
+    );
+
+    this.disposables.push(
+      vscode.workspace.onDidCloseTextDocument((doc) => {
+        this.diagnosticCollection.delete(doc.uri);
+      }),
+    );
+
+    // Refresh when translation index changes
+    this.disposables.push(
+      this.index.onDidChange(() => {
+        for (const editor of vscode.window.visibleTextEditors) {
+          this.updateDiagnostics(editor.document);
+        }
+      }),
+    );
+
+    // Initial pass on open editors
+    for (const editor of vscode.window.visibleTextEditors) {
+      this.updateDiagnostics(editor.document);
+    }
+  }
+
+  dispose(): void {
+    this.diagnosticCollection.dispose();
+    for (const d of this.disposables) {
+      d.dispose();
+    }
+  }
+
+  private updateDiagnostics(document: vscode.TextDocument): void {
+    if (!this.isSupported(document)) {
+      return;
+    }
+
+    const diagnostics: vscode.Diagnostic[] = [];
+    const text = document.getText();
+    const pattern = /\bt\(\s*["']([^"']+)["']/g;
+    let found: RegExpExecArray | null;
+
+    const allKeys = new Set(this.index.getAllKeys());
+
+    while ((found = pattern.exec(text)) !== null) {
+      const key = found[1];
+      const keyOffset = found.index + found[0].indexOf(key);
+      const startPos = document.positionAt(keyOffset);
+      const endPos = document.positionAt(keyOffset + key.length);
+      const range = new vscode.Range(startPos, endPos);
+
+      if (!allKeys.has(key)) {
+        // Key not found in any locale
+        diagnostics.push(
+          new vscode.Diagnostic(
+            range,
+            `Translation key "${key}" not found in any locale`,
+            vscode.DiagnosticSeverity.Error,
+          ),
+        );
+      } else {
+        // Check for missing locales
+        const missing = this.index.getMissingLocales(key);
+        if (missing.length > 0) {
+          diagnostics.push(
+            new vscode.Diagnostic(
+              range,
+              `Translation key "${key}" is missing in: ${missing.join(", ")}`,
+              vscode.DiagnosticSeverity.Warning,
+            ),
+          );
+        }
+      }
+    }
+
+    this.diagnosticCollection.set(document.uri, diagnostics);
+  }
+
+  private isSupported(document: vscode.TextDocument): boolean {
+    const supported = [
+      "typescript",
+      "typescriptreact",
+      "javascript",
+      "javascriptreact",
+    ];
+    return supported.includes(document.languageId);
+  }
+}

--- a/packages/vscode-extension/src/providers/hover.ts
+++ b/packages/vscode-extension/src/providers/hover.ts
@@ -1,0 +1,64 @@
+import * as vscode from "vscode";
+import { TranslationIndex } from "../translation-index";
+
+/**
+ * Shows translation values on hover when the cursor is over a translation key
+ * inside a t("...") call.
+ */
+export class TranslationHoverProvider implements vscode.HoverProvider {
+  constructor(private readonly index: TranslationIndex) {}
+
+  provideHover(
+    document: vscode.TextDocument,
+    position: vscode.Position,
+  ): vscode.Hover | undefined {
+    const key = this.extractKeyAtPosition(document, position);
+    if (!key) {
+      return undefined;
+    }
+
+    const entries = this.index.getEntries(key);
+    if (entries.length === 0) {
+      return undefined;
+    }
+
+    const lines = entries.map(
+      (entry) => `**${entry.locale}**: ${entry.value}`,
+    );
+
+    const markdown = new vscode.MarkdownString();
+    markdown.appendMarkdown(`### Translation: \`${key}\`\n\n`);
+    markdown.appendMarkdown(lines.join("\n\n"));
+
+    const missingLocales = this.index.getMissingLocales(key);
+    if (missingLocales.length > 0) {
+      markdown.appendMarkdown(
+        `\n\n---\n\n*Missing in: ${missingLocales.join(", ")}*`,
+      );
+    }
+
+    return new vscode.Hover(markdown);
+  }
+
+  private extractKeyAtPosition(
+    document: vscode.TextDocument,
+    position: vscode.Position,
+  ): string | undefined {
+    const line = document.lineAt(position).text;
+
+    // Find all t("key") or t('key') occurrences in the line
+    const pattern = /\bt\(\s*["']([^"']+)["']/g;
+    let result: RegExpExecArray | null;
+
+    while ((result = pattern.exec(line)) !== null) {
+      const keyStart = result.index + result[0].indexOf(result[1]);
+      const keyEnd = keyStart + result[1].length;
+
+      if (position.character >= keyStart && position.character <= keyEnd) {
+        return result[1];
+      }
+    }
+
+    return undefined;
+  }
+}

--- a/packages/vscode-extension/src/translation-index.ts
+++ b/packages/vscode-extension/src/translation-index.ts
@@ -1,0 +1,206 @@
+import * as vscode from "vscode";
+import * as path from "path";
+
+export interface TranslationEntry {
+  key: string;
+  value: string;
+  locale: string;
+  filePath: string;
+}
+
+/**
+ * Watches translation JSON files in the workspace and maintains
+ * a flattened key-value index per locale for fast lookups.
+ */
+export class TranslationIndex {
+  /** locale -> (flatKey -> TranslationEntry) */
+  private index = new Map<string, Map<string, TranslationEntry>>();
+  private fileWatcher: vscode.FileSystemWatcher | undefined;
+  private readonly onDidChangeEmitter = new vscode.EventEmitter<void>();
+  public readonly onDidChange = this.onDidChangeEmitter.event;
+
+  async initialize(): Promise<void> {
+    await this.buildIndex();
+    this.setupFileWatcher();
+  }
+
+  dispose(): void {
+    this.fileWatcher?.dispose();
+    this.onDidChangeEmitter.dispose();
+  }
+
+  /** Return all known translation keys (union across locales). */
+  getAllKeys(): string[] {
+    const keys = new Set<string>();
+    for (const localeMap of this.index.values()) {
+      for (const key of localeMap.keys()) {
+        keys.add(key);
+      }
+    }
+    return Array.from(keys);
+  }
+
+  /** Get the translation value for a key in a given locale. */
+  getValue(key: string, locale: string): string | undefined {
+    return this.index.get(locale)?.get(key)?.value;
+  }
+
+  /** Get all entries (across locales) for a given key. */
+  getEntries(key: string): TranslationEntry[] {
+    const entries: TranslationEntry[] = [];
+    for (const localeMap of this.index.values()) {
+      const entry = localeMap.get(key);
+      if (entry) {
+        entries.push(entry);
+      }
+    }
+    return entries;
+  }
+
+  /** Get locales that are missing a specific key. */
+  getMissingLocales(key: string): string[] {
+    const allLocales = Array.from(this.index.keys());
+    return allLocales.filter((locale) => !this.index.get(locale)?.has(key));
+  }
+
+  /** Get all known locales. */
+  getLocales(): string[] {
+    return Array.from(this.index.keys());
+  }
+
+  /** Force a full rebuild of the index. */
+  async refresh(): Promise<void> {
+    this.index.clear();
+    await this.buildIndex();
+    this.onDidChangeEmitter.fire();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Private helpers
+  // ---------------------------------------------------------------------------
+
+  private getGlobPattern(): string {
+    const config = vscode.workspace.getConfiguration("intl-party");
+    return config.get<string>("translationFiles", "**/locales/**/*.json");
+  }
+
+  private async buildIndex(): Promise<void> {
+    const pattern = this.getGlobPattern();
+    const files = await vscode.workspace.findFiles(pattern, "**/node_modules/**");
+
+    for (const file of files) {
+      await this.indexFile(file);
+    }
+  }
+
+  private async indexFile(uri: vscode.Uri): Promise<void> {
+    try {
+      const raw = await vscode.workspace.fs.readFile(uri);
+      const json = JSON.parse(Buffer.from(raw).toString("utf-8"));
+      const locale = this.inferLocale(uri);
+
+      if (!locale) return;
+
+      if (!this.index.has(locale)) {
+        this.index.set(locale, new Map());
+      }
+
+      const flat = this.flatten(json);
+      const localeMap = this.index.get(locale)!;
+
+      for (const [key, value] of Object.entries(flat)) {
+        localeMap.set(key, {
+          key,
+          value: String(value),
+          locale,
+          filePath: uri.fsPath,
+        });
+      }
+    } catch {
+      // Silently ignore files that can't be parsed
+    }
+  }
+
+  /**
+   * Infer locale from the file path. Supports patterns like:
+   *   locales/en/common.json  -> "en"
+   *   locales/en.json         -> "en"
+   *   i18n/fr-FR/messages.json -> "fr-FR"
+   */
+  private inferLocale(uri: vscode.Uri): string | undefined {
+    const parts = uri.fsPath.split(path.sep);
+    // Walk backwards looking for a locale-like segment
+    for (let i = parts.length - 2; i >= 0; i--) {
+      const segment = parts[i];
+      if (/^[a-z]{2}(-[A-Z]{2})?$/.test(segment)) {
+        return segment;
+      }
+    }
+    // Fall back: use filename without extension
+    const basename = path.basename(uri.fsPath, ".json");
+    if (/^[a-z]{2}(-[A-Z]{2})?$/.test(basename)) {
+      return basename;
+    }
+    return undefined;
+  }
+
+  /** Flatten nested JSON into dot-separated keys. */
+  private flatten(
+    obj: Record<string, unknown>,
+    prefix = "",
+  ): Record<string, string> {
+    const result: Record<string, string> = {};
+
+    for (const [key, value] of Object.entries(obj)) {
+      const fullKey = prefix ? `${prefix}.${key}` : key;
+
+      if (typeof value === "object" && value !== null && !Array.isArray(value)) {
+        Object.assign(result, this.flatten(value as Record<string, unknown>, fullKey));
+      } else {
+        result[fullKey] = String(value ?? "");
+      }
+    }
+
+    return result;
+  }
+
+  private setupFileWatcher(): void {
+    const pattern = this.getGlobPattern();
+    this.fileWatcher = vscode.workspace.createFileSystemWatcher(pattern);
+
+    const handleChange = async (uri: vscode.Uri) => {
+      // Re-index the specific locale for this file
+      const locale = this.inferLocale(uri);
+      if (locale) {
+        // Remove old entries from this file
+        const localeMap = this.index.get(locale);
+        if (localeMap) {
+          for (const [key, entry] of localeMap) {
+            if (entry.filePath === uri.fsPath) {
+              localeMap.delete(key);
+            }
+          }
+        }
+      }
+      await this.indexFile(uri);
+      this.onDidChangeEmitter.fire();
+    };
+
+    this.fileWatcher.onDidChange(handleChange);
+    this.fileWatcher.onDidCreate(handleChange);
+    this.fileWatcher.onDidDelete(async (uri) => {
+      const locale = this.inferLocale(uri);
+      if (locale) {
+        const localeMap = this.index.get(locale);
+        if (localeMap) {
+          for (const [key, entry] of localeMap) {
+            if (entry.filePath === uri.fsPath) {
+              localeMap.delete(key);
+            }
+          }
+        }
+        this.onDidChangeEmitter.fire();
+      }
+    });
+  }
+}

--- a/packages/vscode-extension/tsconfig.json
+++ b/packages/vscode-extension/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "lib": ["ES2020"],
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -430,6 +430,18 @@ importers:
         specifier: ^3.2.4
         version: 3.2.4(@types/node@22.18.11)(jsdom@27.0.0(postcss@8.5.6))(terser@5.46.1)
 
+  packages/vscode-extension:
+    devDependencies:
+      '@types/vscode':
+        specifier: ^1.85.0
+        version: 1.110.0
+      tsup:
+        specifier: ^8.5.1
+        version: 8.5.1(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
+      typescript:
+        specifier: ^5.3.0
+        version: 5.9.3
+
 packages:
 
   '@adobe/css-tools@4.4.4':
@@ -1612,6 +1624,9 @@ packages:
 
   '@types/through@0.0.33':
     resolution: {integrity: sha512-HsJ+z3QuETzP3cswwtzt2vEIiHBk/dCcHGhbmG5X3ecnwFD/lPrMpliGXxSCg03L9AhrdwA4Oz/qfspkDW+xGQ==}
+
+  '@types/vscode@1.110.0':
+    resolution: {integrity: sha512-AGuxUEpU4F4mfuQjxPPaQVyuOMhs+VT/xRok1jiHVBubHK7lBRvCuOMZG0LKUwxncrPorJ5qq/uil3IdZBd5lA==}
 
   '@types/yargs-parser@21.0.3':
     resolution: {integrity: sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==}
@@ -5887,6 +5902,8 @@ snapshots:
   '@types/through@0.0.33':
     dependencies:
       '@types/node': 20.19.22
+
+  '@types/vscode@1.110.0': {}
 
   '@types/yargs-parser@21.0.3': {}
 


### PR DESCRIPTION
## Summary
- New VS Code extension package with translation key autocomplete in `t()` calls
- Hover preview showing translation values for current locale
- Missing key diagnostics highlighting
- Go-to-definition for translation keys
- File watcher keeps translation index fresh

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)