### PR TITLE
fix(release): exclude VS Code extension from npm publish

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,5 +7,5 @@
   "access": "public",
   "baseBranch": "master",
   "updateInternalDependencies": "patch",
-  "ignore": ["example-*"]
+  "ignore": ["example-*", "intl-party-vscode"]
 }

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -1,5 +1,6 @@
 {
   "name": "intl-party-vscode",
+  "private": true,
   "displayName": "intl-party",
   "description": "VS Code extension for intl-party - translation key autocomplete, hover preview, diagnostics, and go-to-definition",
   "version": "0.1.0",


### PR DESCRIPTION
## Summary
- Mark `intl-party-vscode` as `"private": true` to prevent `changeset publish` from pushing it to npm (VS Code extensions are distributed via the VS Code Marketplace, not npm)
- Add `intl-party-vscode` to the changesets `ignore` list to exclude it from version bumps and release PRs

Fixes the E404 errors in the release job where `intl-party-vscode@0.1.0` and `@intl-party/react-native@0.1.0` failed to publish. The react-native package should succeed on the next run since the npm org already exists.

## Test plan
- [ ] Merge and verify the release workflow passes without E404 for `intl-party-vscode`
- [ ] Confirm `@intl-party/react-native` publishes successfully on next changeset release

🤖 Generated with [Claude Code](https://claude.com/claude-code)